### PR TITLE
docs: Remove `tower::util::ServiceExt::oneshot` from `README.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet.
+### Changed
+
+- Removed `tower::util::ServiceExt::oneshot` from `README.md`, hinting instead merely at serving the app with `hyper::Server`. (#17, #20)
 
 ## [0.2.2] - 2022-12-01
 

--- a/README.md
+++ b/README.md
@@ -137,13 +137,6 @@ let app = Router::new()
  .layer(SessionLayer::new(MemoryStore::new(), &secret));
 
 // Use hyper to run `app` as service and expose on a local port or socket.
-
-use tower::util::ServiceExt;
-tokio_test::block_on(async {
-    app.oneshot(
-        axum::http::Request::builder().body(axum::body::Body::empty()).unwrap()
-    ).await.unwrap();
-})
 ```
 
 Receive the token and send same-site requests, using your custom header:
@@ -213,13 +206,6 @@ let app = Router::new()
 );
 
 // Use hyper to run `app` as service and expose on a local port or socket.
-
-use tower::util::ServiceExt;
-tokio_test::block_on(async {
-    app.oneshot(
-        axum::http::Request::builder().body(axum::body::Body::empty()).unwrap()
-    ).await.unwrap();
-})
 ```
 
 Receive the token and send cross-site requests, using your custom header:


### PR DESCRIPTION
Fixes #17 